### PR TITLE
chore: reuse or pin local Actions + Dependabot

### DIFF
--- a/.github/workflows/devto-publisher-validator.yml
+++ b/.github/workflows/devto-publisher-validator.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate Dev.to articles tags
         run: |
@@ -96,11 +96,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate articles to Dev.to
         id: validate_articles
-        uses: sinedied/publish-devto@v2
+        uses: sinedied/publish-devto@c713cc0934b35cb3df9fca759b98e36e6a540a85 # v2
         with:
           devto_key: ${{ secrets.DEVTO_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -125,11 +125,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Publish articles to Dev.to
         id: publish_articles
-        uses: sinedied/publish-devto@v2
+        uses: sinedied/publish-devto@c713cc0934b35cb3df9fca759b98e36e6a540a85 # v2
         with:
           devto_key: ${{ secrets.DEVTO_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,41 +1,14 @@
-name: Markdown Linter
+name: Markdown Lint
 
 on:
-  push:
-    branches:
-      - "**"
-    paths:
-      - "**/*.md"
+  pull_request: {}
+
+permissions:
+  statuses: write
+  checks: write
+  contents: read
+  pull-requests: read
 
 jobs:
   markdown-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install markdownlint
-        run: npm install -g markdownlint-cli@0.41.0
-
-      - name: Run markdownlint
-        env:
-          CONFIG: |
-            {
-              "comment": "Default rules",
-              "default": true,
-              "whitespace": true,
-              "line_length": false,
-              "ul-start-left": true,
-              "ul-indent": true,
-              "no-inline-html": true,
-              "no-bare-urls": true,
-              "fenced-code-language": true,
-              "first-line-h1": true,
-              "no-duplicate-header": true,
-              "no-emphasis-as-header": true,
-              "single-h1": true
-            }
-        run: |
-          CONFIG_FILE="$(mktemp)"
-          echo "$CONFIG" > "$CONFIG_FILE"
-          markdownlint '**/*.md' --ignore node_modules -c "$CONFIG_FILE"
+    uses: actionsforge/actions/.github/workflows/markdown-lint.yml@main


### PR DESCRIPTION
## Summary
- Convert `validate-devschema` / custom markdown-lint to actionsforge reusables where they fit
- SHA-pin remaining floating marketplace actions
- Add Dependabot for `github-actions` when missing

## Test plan
- [ ] Required workflow checks pass